### PR TITLE
Fix typos in README, update subcommand help text

### DIFF
--- a/BENCH.md
+++ b/BENCH.md
@@ -12,7 +12,7 @@ a rough estimate of performance differences.
 
 # Nsbox vs unbox
 
-I was not able to get nsbox to work for this benchmark
+I was not able to get `nsbox` to work for this benchmark
 
 # Devbox vs unbox
 

--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
 # Unbox
 
-`unbox` or `unshare-toolbox` is an independent reimplementation of the ideas developed by [toolbx](https://containertoolbx.org/).
-It does _not_ use established container runtimes (`podman`, `docker`, `systemd-spawn`, etc) to isolate the processes but instead it
-is implemented directly with Linux Nampespaces to provide the environment of execution. For the creation of the images it is possible
+`unbox` or `unshare-toolbox` is an independent reimplementation of the ideas developed by [`toolbx`](https://containertoolbx.org/).
+It does _not_ use established container runtimes (`podman`, `docker`, `systemd-spawn`, etc) to isolate the processes, but instead it
+is implemented directly with Linux Namespaces to provide the environment of execution. For the creation of the images it is possible
 to use existing OCI images.
 
 > **Warning**
 > The implementation is still very young, and has not been "battle tested" at all, the only usage to my knowledge has been in my personal
 > computer. If you find any bugs, please open an issue.
 
-## Instalation
+## Installation
 
-There are no distro packages available yet, so the preferred way to install is to download the appropiate binary from the [releases page.](https://github.com/lopukhov/unbox/releases)
+There are no distro packages available yet, so the preferred way to install is to download the appropriate binary from the [releases page.](https://github.com/lopukhov/unbox/releases)
 
 ### From source
 
 `unbox` can also be installed from source. You should install `Rust` and `cargo` first following [these instructions.](https://www.rust-lang.org/tools/install)
 
-If you have [just](https://github.com/casey/just) installed you can build using the `native` option for the most optimized experience:
+If you have [`just`](https://github.com/casey/just) installed you can build using the `native` option for the most optimized experience:
 
 ```sh
 $ just native
@@ -56,7 +56,7 @@ If the rootfs is contained in a tarball it can be created from the following com
 $ unbox create <name> -t <path to rootfs.tar>
 ```
 
-If `podman` or `docker` are installed an OCI image can be downloaded an used, note that it may take a while if the image has not already been downloaded:
+If `podman` or `docker` are installed an OCI image can be downloaded and used, note that it may take a while if the image has not already been downloaded:
 
 ```sh
 $ unbox create <name> -i <url for the image> -e <engine to be used>
@@ -112,20 +112,20 @@ There are a number of different implementations of the ideas originally develope
 to flesh out their strengths and weaknesses. This comparison should not be regarded as absolute truth as it may be biased by my opinions and interests
 or lose accuracy with new developments in each of the different implementations.
 
-| Implementation                                     | Language | Based on         | Image                  | Time to enter |
-| -------------------------------------------------- | -------- | ---------------- | ---------------------- | ------------- |
-| [toolbx](https://github.com/containers/toolbox)    | Go       | podman           | OCI images             | 837 ms        |
-| [distrobox](https://github.com/89luca89/distrobox) | Shell    | podman or docker | OCI images             | 284 ms        |
-| [nsbox](https://github.com/refi64/nsbox)           | Go       | systemd-nspawn   | Ansible                | --- ms        |
-| [devbox](https://github.com/jetpack-io/devbox)     | Go       | nix-shell        | -                      | --- ms        |
-| [unbox](https://github.com/lopukhov/unbox)         | Rust     | -                | OCI images or tarballs |   1 ms        |
+| Implementation                                       | Language | Based on             | Image                  | Time to enter |
+|------------------------------------------------------|----------|----------------------|------------------------|---------------|
+| [`toolbx`](https://github.com/containers/toolbox)    | Go       | `podman`             | OCI images             | 837 ms        |
+| [`distrobox`](https://github.com/89luca89/distrobox) | Shell    | `podman` or `docker` | OCI images             | 284 ms        |
+| [`nsbox`](https://github.com/refi64/nsbox)           | Go       | `systemd-nspawn`     | Ansible                | --- ms        |
+| [`devbox`](https://github.com/jetpack-io/devbox)     | Go       | `nix-shell`          | -                      | --- ms        |
+| [`unbox`](https://github.com/lopukhov/unbox)         | Rust     | -                    | OCI images or tarballs | 1 ms          |
 
 For the source of the "Time to enter" metric check [here](BENCH.md)
 
 ### Toolbx
 
 Toolbx is the original implementation and is the default in Fedora Silverblue. This means that it has been more "battle-tested" than the other alternatives,
-with more bugs being found and fixed and more features being considered implemented. Officialy only Fedora images are supported, but it is possible to create
+with more bugs being found and fixed and more features being considered implemented. Officially only Fedora images are supported, but it is possible to create
 images following their documentation for other distributions. In my opinion the most important downsides are the long time to enter into the toolbox and the lack
 of flexibility by using an OCI runtime.
 
@@ -134,12 +134,12 @@ of flexibility by using an OCI runtime.
 Distrobox offers much more choice, from a wider set of tested images and a choice of using either `podman` or `docker` as the container manager. The project also
 has as one of its aims to be fast, and it is significantly faster than the original `toolbx` in my tests. It is probably the second most used implementation, so
 most features are already implemented and a lot of bugs have been fixed. In my opinion the most important downsides are the long time to enter into the toolbox
-(although one of their aims is to be as fast as possible the use of an OCI runtime puts a hard limit on how fast it can run), and the fact that is is written in
+(although one of their aims is to be as fast as possible the use of an OCI runtime puts a hard limit on how fast it can run), and the fact that is written in
 a shell language which I dislike for bigger projects.
 
 ### Devbox
 
-Devbox is a young implementation based on the `Nix` project and it is more focused on giving reproducible environments to developers than on "pet" userspace for
+Devbox is a young implementation based on the `Nix` project, and it is more focused on giving reproducible environments to developers than on "pet" userspace for
 immutable distributions. In my opinion the biggest downside is the usage of `Nix`, which is not a pleasant experience to use in `ostree` distributions like
 Fedora Silverblue. Another downside that it shares with `unbox` is that because it is a younger project some features might be missing or some bugs may not have been
 found.

--- a/justfile
+++ b/justfile
@@ -7,7 +7,7 @@ check:
   cargo clippy
   cargo test
 
-# Profile the appropiate benchmark
+# Profile the appropriate benchmark
 profile SUITE BENCH:
   cargo bench --bench {{SUITE}} -- --profile-time 60 {{BENCH}}
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,17 +38,17 @@ enum Subcommands {
     List(List),
 }
 
-/// Create the unbox rootfs from an image
+/// Create a toolbox rootfs from an image
 #[derive(Args, PartialEq, Eq, Debug)]
 pub struct Create {
     #[clap(value_parser)]
-    /// name of the unbox
+    /// Name of the toolbox
     name: String,
     #[clap(short, long, value_parser)]
-    /// path to the tarball
+    /// Path to the tarball
     tar: Option<PathBuf>,
     #[clap(short, long, value_parser)]
-    /// url of the OCI image
+    /// Url of the OCI image
     image: Option<String>,
     #[clap(short, long, value_parser)]
     /// OCI engine to extract the rootfs
@@ -62,37 +62,37 @@ enum Engine {
     Podman,
 }
 
-/// Enter the unbox
+/// Enter a toolbox
 #[derive(Args, PartialEq, Eq, Debug)]
 pub struct Enter {
     #[clap(value_parser)]
-    /// name of the unbox
+    /// Name of the toolbox
     name: String,
 }
 
-/// Run a command in the unbox
+/// Run a command in a toolbox
 #[derive(Args, PartialEq, Eq, Debug)]
 pub struct Run {
     #[clap(value_parser)]
-    /// name of the unbox
+    /// Name of the toolbox
     name: String,
     #[clap(value_parser)]
-    /// command to run
+    /// Command to run
     cmd: String,
-    /// command arguments
+    /// Command arguments
     #[clap(value_parser)]
     args: Vec<String>,
 }
 
-/// Remove an unbox
+/// Remove a toolbox
 #[derive(Args, PartialEq, Eq, Debug)]
 struct Remove {
     #[clap(value_parser)]
-    /// name of the unbox
+    /// Name of the toolbox
     name: String,
 }
 
-/// List unboxes
+/// List toolboxes
 #[derive(Args, PartialEq, Eq, Debug)]
 struct List {}
 


### PR DESCRIPTION
Cleaned up a few more typos in the README, as well as consistently applying backticks around tools. I didn't format some that seemed like titles or more like proper nouns, but feel like those could be updated as well.

The changes to the subcommand help text normalizes the output compared to `clap`'s output, ex:

```text
OPTIONS:
    -h, --help       Print help information
    -V, --version    Print version information

SUBCOMMANDS:
    create    Create the unbox rootfs from an image
    enter     Enter the unbox
    help      Print this message or the help of the given subcommand(s)
    list      List unboxes
    remove    Remove an unbox
    run       Run a command in the unbox
```

Subcommand output goes from:

```text
ARGS:
    <NAME>    name of the unbox

OPTIONS:
    -e, --engine <ENGINE>    OCI engine to extract the rootfs [possible values: docker, podman]
    -h, --help               Print help information
    -i, --image <IMAGE>      url of the OCI image
    -t, --tar <TAR>          path to the tarball
```
to...
```text
ARGS:
    <NAME>    Name of the toolbox

OPTIONS:
    -e, --engine <ENGINE>    OCI engine to extract the rootfs [possible values: docker, podman]
    -h, --help               Print help information
    -i, --image <IMAGE>      Url of the OCI image
    -t, --tar <TAR>          Path to the tarball
```

This also removes the usage of "unbox" in command descriptions, preferring "toolbox" to be consistent with the README and the tool's description of:

> Unshare a toolbox