### PR TITLE
Hide set mappings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,7 +372,7 @@ checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "unbox"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "clap",
  "color-eyre",

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,7 @@ enum Subcommands {
     Remove(Remove),
     #[clap(alias = "ls")]
     List(List),
+    #[clap(hide = true)]
     SetMappings(SetMappings),
 }
 


### PR DESCRIPTION
Include derive for hidden subcommand, rather than just including a warning comment. Subcommand and it's individual help text is still available from:

```bash
❯ ./target/debug/unbox set-mappings --help
unbox-set-mappings 
Internal subcommand. Should not be used directly

USAGE:
    unbox set-mappings [ARGS]...

ARGS:
    <ARGS>...    Command arguments

OPTIONS:
    -h, --help    Print help information
```